### PR TITLE
Split lexicase, logging, and complexity

### DIFF
--- a/feat/feat.py
+++ b/feat/feat.py
@@ -68,7 +68,7 @@ class Feat(BaseEstimator):
         Random seed. If -1, will choose a random random_state.
     erc: boolean, optional (default: False)
         If true, ephemeral random constants are included as nodes in trees.
-    objectives: list[str], optional (default: "fitness,complexity")
+    objectives: list[str], optional (default: ["fitness","complexity"])
         Objectives to use for multi-objective optimization.
     shuffle: boolean, optional (default: True)
         Whether to shuffle the training data before beginning training.
@@ -399,9 +399,9 @@ class Feat(BaseEstimator):
     def get_model(self, sort=True): return self.cfeat_.get_model(sort)
     def get_coefs(self): return self.cfeat_.get_coefs()
     def get_n_params(self): return self.cfeat_.get_n_params()
-    def get_complexity(self): return self.cfeat_.get_complexity()
     def get_dim(self): return self.cfeat_.get_dim()
     def get_n_nodes(self): return self.cfeat_.get_n_nodes()
+    def get_complexity(self): return self.cfeat_.get_complexity()
 
 class FeatRegressor(Feat):
     """Convenience method that enforces regression options."""

--- a/feat/feat.py
+++ b/feat/feat.py
@@ -399,6 +399,7 @@ class Feat(BaseEstimator):
     def get_model(self, sort=True): return self.cfeat_.get_model(sort)
     def get_coefs(self): return self.cfeat_.get_coefs()
     def get_n_params(self): return self.cfeat_.get_n_params()
+    def get_complexity(self): return self.cfeat_.get_complexity()
     def get_dim(self): return self.cfeat_.get_dim()
     def get_n_nodes(self): return self.cfeat_.get_n_nodes()
 

--- a/src/feat.cc
+++ b/src/feat.cc
@@ -1392,29 +1392,55 @@ void Feat::calculate_stats(const DataRef& d)
         ++i;
     }
 
-    // number of test cases in lexicase selection
+    // number of test cases in lexicase-based selection methods
     VectorXf n_cases_used(this->pop.size());
+    VectorXf thresholds(this->pop.size());
 
-    vector<size_t> v;
-    v.resize(this->pop.size());
+    vector<size_t> cases_vector;
+    cases_vector.resize(this->pop.size());
+
+    vector<float> thresholds_vector;
+    thresholds_vector.resize(this->pop.size());
     
+    // TODO: stop casting. just change from vector to vectorXf inside lexicases
     // TODO: maybe a getter function to get pselector?
-    // TODO: implement track of number of cases used to all lexicases
-    if (this->selector.get_type() == "pareto_lexicase")
-        v = dynamic_cast<ParetoLexicase*>(this->selector.pselector.get())->n_cases_used;
-    else if (this->selector.get_type() == "lexicase")
-        v = dynamic_cast<Lexicase*>(this->selector.pselector.get())->n_cases_used;
-    else if (this->selector.get_type() == "split_lexicase")
-        v = dynamic_cast<SplitLexicase*>(this->selector.pselector.get())->n_cases_used;
-    else
-        std::fill(v.begin(), v.end(), 0);
+    // TODO: implement track of number of cases used to all lexicases?
+    if (this->selector.get_type() == "pareto_lexicase") {
+        cases_vector = dynamic_cast<ParetoLexicase*>
+                        (this->selector.pselector.get())->n_cases_used;
+        thresholds_vector = dynamic_cast<ParetoLexicase*>
+                            (this->selector.pselector.get())->thresholds;
+    }
+    else if (this->selector.get_type() == "lexicase") {
+        cases_vector = dynamic_cast<Lexicase*>
+                        (this->selector.pselector.get())->n_cases_used;
+        thresholds_vector = dynamic_cast<Lexicase*>
+                            (this->selector.pselector.get())->thresholds;
+    }
+    else if (this->selector.get_type() == "split_lexicase") {
+        cases_vector = dynamic_cast<SplitLexicase*>
+                        (this->selector.pselector.get())->n_cases_used;
+        thresholds_vector = dynamic_cast<SplitLexicase*>
+                            (this->selector.pselector.get())->thresholds;
+    }
+    else {
+        std::fill(cases_vector.begin(), cases_vector.end(), 0);
+        std::fill(thresholds_vector.begin(), thresholds_vector.end(), 0);
+    }
 
-    for (size_t i=0; i<this->pop.size(); i++)
-        n_cases_used(i) = v.at(i);
+    // casting to use custom functions
+    for (size_t i=0; i<this->pop.size(); i++) {
+        n_cases_used(i) = cases_vector.at(i);
+        thresholds(i) = thresholds_vector.at(i);
+    }
 
     unsigned min_tests_used = n_cases_used.minCoeff();
     unsigned med_tests_used = median(n_cases_used.array());  
     unsigned max_tests_used = n_cases_used.maxCoeff();  
+
+    float min_threshold = thresholds.minCoeff();
+    float med_threshold = median(thresholds.array());  
+    float max_threshold = thresholds.maxCoeff();  
     
     /* unsigned med_size = median(Sizes); */ 
     unsigned med_complexity = median(Complexities);            
@@ -1453,7 +1479,10 @@ void Feat::calculate_stats(const DataRef& d)
                  med_dim,
                  min_tests_used,
                  med_tests_used,
-                 max_tests_used);
+                 max_tests_used,
+                 min_threshold,
+                 med_threshold,
+                 max_threshold);
 }
 
 void Feat::print_stats(std::ofstream& log, float fraction)
@@ -1586,6 +1615,9 @@ void Feat::log_stats(std::ofstream& log)
             << "min_tests_used" << sep
             << "med_tests_used" << sep
             << "max_tests_used" << sep
+            << "min_threshold"  << sep
+            << "med_threshold"  << sep
+            << "max_threshold"  << sep
             << "med_dim"        << "\n";
     }
     log << params.current_gen          << sep
@@ -1600,6 +1632,9 @@ void Feat::log_stats(std::ofstream& log)
         << stats.min_tests_used.back() << sep
         << stats.med_tests_used.back() << sep
         << stats.max_tests_used.back() << sep
+        << stats.min_threshold.back()  << sep
+        << stats.med_threshold.back()  << sep
+        << stats.max_threshold.back()  << sep
         << stats.med_dim.back()        << "\n"; 
 }
 

--- a/src/feat.cc
+++ b/src/feat.cc
@@ -567,7 +567,12 @@ int Feat::get_n_params(){ return best_ind.get_n_params(); }
 int Feat::get_dim(){ return best_ind.get_dim(); } 
 
 ///get dimensionality of best
-int Feat::get_complexity(){ return best_ind.get_complexity(); } 
+int Feat::get_complexity(){
+    // Making sure it is calculated before returning it
+    if (best_ind.get_complexity()==0)
+        best_ind.set_complexity();
+    return best_ind.get_complexity();
+} 
 
 
 /// return the number of nodes in the best model
@@ -710,9 +715,6 @@ void Feat::run_generation(unsigned int g,
     logger.log("update best...",2);
     bool updated_best = update_best(d);
 
-    logger.log("calculate stats...",2);
-    calculate_stats(d);
-
     if (params.max_stall > 0)
         update_stall_count(stall_count, updated_best);
 
@@ -722,6 +724,9 @@ void Feat::run_generation(unsigned int g,
         for (unsigned int i=0; i<pop.size(); ++i)
             pop.individuals.at(i).set_obj(params.objectives);
     }
+
+    logger.log("calculate stats...",2);
+    calculate_stats(d);
 
     logger.log("update archive...",2);
     if (use_arch) 

--- a/src/feat.h
+++ b/src/feat.h
@@ -324,7 +324,7 @@ class Feat
         int get_n_params();
         ///get dimensionality of best
         int get_dim();
-        ///get dimensionality of best
+        ///get complexity of best
         int get_complexity();
         ///return population as string
         vector<nl::json> get_archive(bool front);

--- a/src/pybind.cc
+++ b/src/pybind.cc
@@ -152,6 +152,7 @@ PYBIND11_MODULE(_feat, m)
         .def("get_n_params", &Feat::get_n_params)
         .def("get_dim", &Feat::get_dim)
         .def("get_n_nodes", &Feat::get_n_nodes)
+        .def("get_complexity", &Feat::get_complexity)
         .def("get_model", &Feat::get_model, py::arg("sort") = true)
         .def("get_eqn", &Feat::get_eqn, py::arg("sort") = true)
         ;

--- a/src/sel/lexicase.h
+++ b/src/sel/lexicase.h
@@ -33,6 +33,10 @@ namespace Sel{
 
         // number of test cases used to select each of the selected individuals
         vector<size_t> n_cases_used;
+
+        // split or epsilon threshold to remain in the pool before picking the
+        // final individual
+        vector<float> thresholds;
     };
 }
 

--- a/src/sel/pareto_lexicase.cc
+++ b/src/sel/pareto_lexicase.cc
@@ -54,6 +54,10 @@ vector<size_t> ParetoLexicase::select(Population& pop,
     n_cases_used.resize(P);
     std::iota(n_cases_used.begin(), n_cases_used.end(), 0);
     
+    // threshold used to pick each individual
+    thresholds.resize(P);
+    std::iota(thresholds.begin(), thresholds.end(), 0);
+
     // selection loop
     #pragma omp parallel for 
     for (unsigned int i = 0; i<P; ++i)
@@ -90,9 +94,12 @@ vector<size_t> ParetoLexicase::select(Population& pop,
         bool pass = true;     // checks pool size and number of cases
         unsigned int h = 0;   // case count, index used in cases[h]
 
+        float error_epsilon;
+
         while(pass){    // main loop
             // Calculating epsilons on demand
-            float error_epsilon = 0;
+            error_epsilon = 0;
+
             // if output is continuous, use epsilon lexicase            
             if (!params.classification || params.scorer_.compare("log")==0 
             ||  params.scorer_.compare("multi_log")==0)
@@ -142,6 +149,7 @@ vector<size_t> ParetoLexicase::select(Population& pop,
         assert(winner.size()>0);
 
         n_cases_used[i] = h;
+        thresholds[i]   = error_epsilon;
 
         //if more than one winner, pick randomly
         selected.at(i) = r.random_choice(winner);   

--- a/src/sel/pareto_lexicase.h
+++ b/src/sel/pareto_lexicase.h
@@ -37,6 +37,10 @@ namespace Sel{
         // number of test cases used to select each of the selected individuals
         vector<size_t> n_cases_used;
 
+        // split or epsilon threshold to remain in the pool before picking the
+        // final individual (just the error threshold, not the size)
+        vector<float> thresholds;
+
         private:
 
             //< dominance comparison with epison relaxation

--- a/src/sel/split_lexicase.cc
+++ b/src/sel/split_lexicase.cc
@@ -103,8 +103,14 @@ vector<size_t> SplitLexicase::select(Population& pop,
                 split_threshold = find_threshold(pool_error);
             }
 
-            // everyone is on one side of the partition
-            if (split_threshold==0) {
+            float min_error = pool_error.minCoeff();
+            float max_error = pool_error.maxCoeff();
+
+            // handling when everyone is on the same side of the partition
+            if (split_threshold==0 // numeric error inside `find_threshold`
+            || (split_threshold<min_error // no one would be selected
+            ||  split_threshold>=max_error) // everyone is selected
+            ) {
                 continue;
             }
             

--- a/src/sel/split_lexicase.cc
+++ b/src/sel/split_lexicase.cc
@@ -89,6 +89,8 @@ vector<size_t> SplitLexicase::select(Population& pop,
         while(pass){    // main loop
             // Calculating epsilon on demand
             split_threshold = 0;
+            float min_error = 0;
+            float max_error = 0;
 
             // TODO: handle classification and regression here
             // if output is continuous, use epsilon lexicase            
@@ -100,15 +102,15 @@ vector<size_t> SplitLexicase::select(Population& pop,
                 {
                     pool_error(j) = pop.individuals.at(pool[j]).error(cases[h]);
                 }
+                
                 split_threshold = find_threshold(pool_error);
+                min_error = pool_error.minCoeff();
+                max_error = pool_error.maxCoeff();
             }
-
-            float min_error = pool_error.minCoeff();
-            float max_error = pool_error.maxCoeff();
 
             // handling when everyone is on the same side of the partition
             if (split_threshold==0 // numeric error inside `find_threshold`
-            || (split_threshold<min_error // no one would be selected
+            || (split_threshold< min_error // no one would be selected
             ||  split_threshold>=max_error) // everyone is selected
             ) {
                 continue;

--- a/src/sel/split_lexicase.h
+++ b/src/sel/split_lexicase.h
@@ -32,6 +32,10 @@ namespace Sel{
         // number of test cases used to select each of the selected individuals
         vector<size_t> n_cases_used;
 
+        // split or epsilon threshold to remain in the pool before picking the
+        // final individual
+        vector<float> thresholds;
+
         private:
             /// Uses a heuristic to set a splitting threshold.
             float find_threshold(const ArrayXf& x);

--- a/src/util/utils.cc
+++ b/src/util/utils.cc
@@ -283,7 +283,10 @@ void Log_Stats::update(int index,
                        unsigned md_dim,
                        unsigned min_tests,
                        unsigned md_tests,
-                       unsigned max_tests)
+                       unsigned max_tests,
+                       float mn_threshold,
+                       float md_threshold,
+                       float mx_threshold)
 {
     generation.push_back(index+1);
     time.push_back(timer_count);
@@ -298,6 +301,9 @@ void Log_Stats::update(int index,
     min_tests_used.push_back(min_tests);
     med_tests_used.push_back(md_tests);
     max_tests_used.push_back(max_tests);
+    min_threshold.push_back(mn_threshold);
+    med_threshold.push_back(md_threshold);
+    max_threshold.push_back(mx_threshold);
 }
 
 std::string ravel(const vector<string>& v, string sep)

--- a/src/util/utils.h
+++ b/src/util/utils.h
@@ -393,6 +393,9 @@ struct Log_Stats
     vector<unsigned> min_tests_used;
     vector<unsigned> med_tests_used;
     vector<unsigned> max_tests_used;
+    vector<float> min_threshold;
+    vector<float> med_threshold;
+    vector<float> max_threshold;
     
     void update(int index,
                 float timer_count,
@@ -406,7 +409,11 @@ struct Log_Stats
                 unsigned md_dim,
                 unsigned min_tests,
                 unsigned md_tests,
-                unsigned max_tests);
+                unsigned max_tests,
+                float mn_threshold,
+                float md_threshold,
+                float mx_threshold
+                );
 };
 
 typedef struct Log_Stats Log_stats;
@@ -421,6 +428,12 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Log_Stats,
     med_size,
     med_complexity,
     med_num_params,
+    min_tests_used,
+    med_tests_used,
+    max_tests_used,
+    min_threshold,
+    med_threshold,
+    max_threshold,
     med_dim);
 
 ///template function to convert objects to string for logging

--- a/tests/wrappertest.py
+++ b/tests/wrappertest.py
@@ -199,6 +199,9 @@ class TestFeatWrapper(unittest.TestCase):
 
         assert(reg.get_representation() == loaded_reg.get_representation())
         assert(reg.get_model() == loaded_reg.get_model())
+        assert(reg.get_complexity() == loaded_reg.get_complexity())
+        assert(reg.get_n_params() == loaded_reg.get_n_params())
+        assert(reg.get_n_nodes() == loaded_reg.get_n_nodes())
         assert((reg.get_coefs() == loaded_reg.get_coefs()).all())
         loaded_params = loaded_reg.get_params()
         # print('\n',10*'=','\n')


### PR DESCRIPTION
This PR adds the threshold used in lexicase into the log files; fixes split lexicase by ignoring cases where everyone is at the same side of the split; and adds a `get_complexity` function (also fixes complexity not being calculated previously).